### PR TITLE
Add pathing from the Account type down to child accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ val wallet = Wallet.fromSeed(hrp, seed)
 // Convert a mnemonic into a wallet:
 val wallet = Wallet.fromMnemonic(hrp, "passphrase".toCharArray(), wordlist)
 
-// Convert a base58-encoded bip32 key into an account:
+// Convert a base58-encoded bip32 key into an account and derive a child key / account:
+val testnetPath = "m/44'/1'/0'/0/0"
 val account = Account.fromBip32(hrp, base58EncodedBip32Key)
+val childAccount = account[testnetPath]
 
 // Generate a bech32 address for the account:
 val address = account.address

--- a/hdwallet/src/main/kotlin/tech/figure/hdwallet/wallet/DefaultWallet.kt
+++ b/hdwallet/src/main/kotlin/tech/figure/hdwallet/wallet/DefaultWallet.kt
@@ -37,4 +37,10 @@ class DefaultAccount(
 
     override fun get(index: Int, hardened: Boolean): Account =
         DefaultAccount(hrp, key.childKey(index, hardened), signer)
+
+    override fun get(path: List<PathElement>): Account =
+        DefaultAccount(hrp, key.childKey(path))
+
+    override fun get(path: String): Account =
+        DefaultAccount(hrp, key.childKey(path))
 }

--- a/hdwallet/src/main/kotlin/tech/figure/hdwallet/wallet/Wallet.kt
+++ b/hdwallet/src/main/kotlin/tech/figure/hdwallet/wallet/Wallet.kt
@@ -182,13 +182,3 @@ interface Account {
 interface Discoverer {
     fun discover(account: Account, query: (path: String) -> List<Account>): List<Account>
 }
-
-fun main() {
-    val oldPath = "m/44'/1'/0'/0/0'"
-    val bip = "tprv8ZgxMBicQKsPdrxuJ4ysJFdiqsGREQ6osTJTisi1Pu8HS85cDkikq3Etzdvvr8EwMAMR7RNCjiETbFC3RHGQvBMSMJEhm3CX1mzmuGwGL61"
-    val rootAccount = Account.fromBip32("tp", bip)
-    val childAccount = rootAccount[oldPath]
-
-    // tp1apnhcu9x5cz2l8hhgnj0hg7ez53jah7hcan000
-    println(childAccount.address)
-}

--- a/hdwallet/src/main/kotlin/tech/figure/hdwallet/wallet/Wallet.kt
+++ b/hdwallet/src/main/kotlin/tech/figure/hdwallet/wallet/Wallet.kt
@@ -13,6 +13,7 @@ import tech.figure.hdwallet.ec.Curve
 import tech.figure.hdwallet.ec.ECKeyPair
 import tech.figure.hdwallet.encoding.base58.base58DecodeChecked
 import java.security.KeyException
+import tech.figure.hdwallet.bip44.parseBIP44Path
 
 /**
  * Wallets are the root key representation used to derive [Account]s.
@@ -152,6 +153,10 @@ interface Account {
      */
     operator fun get(index: Int, hardened: Boolean = true): Account
 
+    operator fun get(path: List<PathElement>): Account
+
+    operator fun get(path: String): Account
+
     companion object {
         /**
          * Convert a base58 check encoded bip32 serialized extended key back into an account.
@@ -176,4 +181,14 @@ interface Account {
  */
 interface Discoverer {
     fun discover(account: Account, query: (path: String) -> List<Account>): List<Account>
+}
+
+fun main() {
+    val oldPath = "m/44'/1'/0'/0/0'"
+    val bip = "tprv8ZgxMBicQKsPdrxuJ4ysJFdiqsGREQ6osTJTisi1Pu8HS85cDkikq3Etzdvvr8EwMAMR7RNCjiETbFC3RHGQvBMSMJEhm3CX1mzmuGwGL61"
+    val rootAccount = Account.fromBip32("tp", bip)
+    val childAccount = rootAccount[oldPath]
+
+    // tp1apnhcu9x5cz2l8hhgnj0hg7ez53jah7hcan000
+    println(childAccount.address)
 }


### PR DESCRIPTION
* Fix boolean hardened check
* Add pathing from the account type down to child accounts. Needed when account is derived from a bip32 xprv key.