### PR TITLE
Simplify public key creation + bug fix + other stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,27 +8,29 @@ HDWallet is a collection of helper utilities to ease use of hierarchical determi
 
 Current published version:
 
-![Maven Central](https://maven-badges.herokuapp.com/maven-central/tech.figure.hdwallet/hdwallet/badge.svg)
+![Maven Central](https://img.shields.io/maven-central/v/tech.figure.hdwallet/hdwallet.svg?label=Maven%20Central)
 
 ```xml
 <dependency>
   <groupId>tech.figure.hdwallet</groupId>
   <artifactId>hdwallet</artifactId>
-  <version>${version}</version>
+  <version>$VERSION</version>
 </dependency>
 ```
 
 ## Gradle
 
 ```kotlin
-implementation("tech.figure.hdwallet", "hdwallet", "$version")
+implementation("tech.figure.hdwallet", "hdwallet", "$VERSION")
 ```
 
 # Quickstart
 
-## Initializing a wallet from a mnemonic set and signing a []byte payload.
+## Wallet operation examples
 
-### Shortcut version
+### Initializing a wallet from a mnemonic set and signing a `ByteArray` payload
+
+#### Shortcut version
 
 ```kotlin
 // Convert a seed into a wallet:
@@ -75,39 +77,83 @@ val payloadHash = "test".toByteArray().sha256()
 val signature = BCECSigner().sign(childKey.keyPair.privateKey, payloadHash)
 ```
 
-## Initializing a key from a bip32 encoded private key
+### Initializing a key from a bip32 encoded private key
 
 ```kotlin
 // Decode the base58-encoded bip32 key into an extKey.
 val extKey: ExtKey = ExtKey.deserialize("<encoded-key>".base58DecodeChecked())
 ```
 
-## Converting between key types
+## Key conversion examples
+
+### Converting a base64 encoded key into a `java.security.PublicKey` using the default (secp256k1) curve
 
 ```kotlin
+import tech.figure.hdwallet.ec.PublicKey
+import tech.figure.hdwallet.ec.extensions.toJavaECPublicKey
+import java.security.PublicKey as JavaPublicKey
+
+val encoded: String = "AmqcgLOp640tgccRYL/+PtKftP0NwHcDNzUiHNsJV+gb"
+val pubKey: JavaPublicKey = PublicKey.fromString().toJavaECPublicKey()
+```
+
+### Convert between private key types
+
+```kotlin
+import tech.figure.hdwallet.bip32.ExtKey
+import tech.figure.hdwallet.ec.Curve
+import tech.figure.hdwallet.ec.ECKeyPair
+import tech.figure.hdwallet.encoding.base58.base58DecodeChecked
+import java.security.PrivateKey as JavaPrivateKey
+
 val extKey: ExtKey = ExtKey.deserialize("<encoded-key>".base58DecodeChecked())
 val keyPair: ECKeyPair = extKey.keyPair
 
-// Convert between private key types:
+// Convert: hdwallet -> Java -> BC -> BigInteger -> ByteArray -> hdwallet
 val privateKey: PrivateKey = keyPair.privateKey
-val javaPrivateKey: java.security.PrivateKey = privateKey.toJavaECPrivateKey()
-val bcPrivateKey: BCECPrivateKey? = javaPrivateKey.toBCECPrivateKey()
-val (bcPrivateBigInt, bcPrivateCurve): Pair<BigInteger, Curve> = bcPublicKey!!.toBigIntegerPair()
+val javaPrivateKey: JavaPrivateKey = privateKey.toJavaECPrivateKey()
+val bcPrivateKey: BCECPrivateKey? = javaPrivateKey.toBCECPrivateKey()  // BouncyCastle
+val (bcPrivateBigInt, curve): Pair<BigInteger, Curve> = bcPublicKey!!.toBigIntegerPair()
 val bytesPrivateKey: ByteArray = bcPrivateBigInt.toByteArray()
 val privateKeyCopy: PrivateKey = PrivateKey.fromBytes(bytesPrivateKey, curve)
 
 // assert(privateKey == privateKeyCopy)
+```
 
-// Convert between public key types:
+### Convert between public key types
+
+```kotlin
+import tech.figure.hdwallet.bip32.ExtKey
+import tech.figure.hdwallet.ec.Curve
+import tech.figure.hdwallet.ec.ECKeyPair
+import tech.figure.hdwallet.ec.PublicKey
+import tech.figure.hdwallet.encoding.base58.base58DecodeChecked
+import java.security.PrivateKey as JavaPrivateKey
+import java.security.PublicKey as JavaPublicKey
+
+val extKey: ExtKey = ExtKey.deserialize("<encoded-key>".base58DecodeChecked())
+val keyPair: ECKeyPair = extKey.keyPair
+
+// Convert: hdwallet -> Java -> BC -> BigInteger -> ByteArray -> hdwallet
 val publicKey: PublicKey = keyPair.publicKey
-val javaPublicKey: java.security.PublicKey = publicKey.toJavaECPublicKey()
-val bcPublicKey: BCECPublicKey? = javaPublicKey.toBCECPublicKey()
-val (bcPublicBigInt, bcPublicCurve): Pair<BigInteger, Curve> =  = bcPublicKey!!.toBigIntegerPair()
+val javaPublicKey: JavaPublicKey = publicKey.toJavaECPublicKey()
+val bcPublicKey: BCECPublicKey? = javaPublicKey.toBCECPublicKey()  // BouncyCastle
+val (bcPublicBigInt, curve): Pair<BigInteger, Curve> = bcPublicKey!!.toBigIntegerPair()
 val bytesPublicKey: ByteArray = bcPublicBigInt.toByteArray()
 val publicKeyCopy: PublicKey = PublicKey.fromBytes(bytesPublicKey, curve)
 
 // assert(publicKey == publicKeyCopy)
+```
 
-// Convert key pairs:
-val javaKeyPair: java.security.KeyPair = keyPair.toJavaECKeyPair()
+### Convert between key pair types
+
+```kotlin
+import tech.figure.hdwallet.ec.PublicKey
+import java.security.PrivateKey as JavaPrivateKey
+import java.security.PublicKey as JavaPublicKey
+import java.security.KeyPair
+
+val extKey: ExtKey = ExtKey.deserialize("<encoded-key>".base58DecodeChecked())
+val keyPair: ECKeyPair = extKey.keyPair
+val javaKeyPair: KeyPair = keyPair.toJavaECKeyPair()
 ```

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ import tech.figure.hdwallet.ec.extensions.toJavaECPublicKey
 import java.security.PublicKey as JavaPublicKey
 
 val encoded: String = "AmqcgLOp640tgccRYL/+PtKftP0NwHcDNzUiHNsJV+gb"
-val pubKey: JavaPublicKey = PublicKey.fromString().toJavaECPublicKey()
+val pubKey: JavaPublicKey = PublicKey.fromString(encoded).toJavaECPublicKey()
 ```
 
 ### Convert between private key types

--- a/bip32/src/main/kotlin/tech/figure/hdwallet/bip32/MasterKey.kt
+++ b/bip32/src/main/kotlin/tech/figure/hdwallet/bip32/MasterKey.kt
@@ -18,6 +18,7 @@ import java.nio.ByteOrder
 import java.security.KeyException
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
+import tech.figure.hdwallet.ec.extensions.packIntoBigInteger
 
 private val BITCOIN_SEED = "Bitcoin seed".toByteArray(Charsets.UTF_8)
 private const val HMAC_SHA512 = "HmacSHA512"
@@ -129,7 +130,7 @@ data class ExtKey(
         val lr = hmacSha512(chainCode.bytes, ext)
         val l = lr.copyOfRange(0, PRIVATE_KEY_SIZE)
         val r = lr.copyOfRange(PRIVATE_KEY_SIZE, PRIVATE_KEY_SIZE + CHAINCODE_SIZE)
-        val ib = l.toBigInteger()
+        val ib = l.packIntoBigInteger()
         require(ib != BigInteger.ZERO && ib < curve.n) {
             "invalid derived key"
         }
@@ -153,7 +154,7 @@ data class ExtKey(
                 .normalize()
             require(!q.isInfinity) { "invalid derived key is zeros" }
             val pt = curve.createPoint(q.x, q.y).encoded(false)
-            val pubk = PublicKey(pt.copyOfRange(1, pt.size).toBigInteger(), curve)
+            val pubk = PublicKey(pt.copyOfRange(1, pt.size).packIntoBigInteger(), curve)
             val prvk = PrivateKey(BigInteger.ZERO, curve)
             ExtKey(versionBytes, nextDepth, fingerprint, account, nextChainCode, ECKeyPair(prvk, pubk))
         }
@@ -211,7 +212,7 @@ fun DeterministicSeed.toRootKey(
     val il = i.copyOfRange(0, PRIVATE_KEY_SIZE)
     val ir = i.copyOfRange(PRIVATE_KEY_SIZE, PRIVATE_KEY_SIZE + CHAINCODE_SIZE)
 
-    val ib = il.toBigInteger()
+    val ib = il.packIntoBigInteger()
     if (ib == BigInteger.ZERO || ib >= curve.n) {
         throw RuntimeException("Invalid key")
     }

--- a/ec/src/main/kotlin/tech/figure/hdwallet/ec/Compression.kt
+++ b/ec/src/main/kotlin/tech/figure/hdwallet/ec/Compression.kt
@@ -1,6 +1,6 @@
 package tech.figure.hdwallet.ec
 
-import tech.figure.hdwallet.ec.extensions.toBigInteger
+import tech.figure.hdwallet.ec.extensions.packIntoBigInteger
 import java.math.BigInteger
 import java.nio.ByteBuffer
 
@@ -14,20 +14,20 @@ internal const val PUBLIC_KEY_SIZE = 64
  *
  * @param compressedBytes The compressed public key bytes to decompress.
  * @param curve The curve to use for decoding the public key point.
- * @return If [encode] is true, The public key will be a packed [BigInteger] 65 bytes long, where the first byte is
- * 0x04, followed by a 32-byte x point coordinate, and a 32-byte y point coordinate. If [encode] is false, the
- * returned [BigInteger] will be 64 bytes, consisting of a 32-byte x point coordinate, followed by a 32-byte y point
- * coordinate.
+ * @return If [legacy] is true, The public key will be a packed [BigInteger] 65 bytes long according to the legacy
+ * format, where the first byte is 0x04, followed by a 32-byte x point coordinate, and a 32-byte y point coordinate.
+ * If [legacy] is false, the returned [BigInteger] will be 64 bytes, consisting of a 32-byte x point coordinate,
+ * followed by a 32-byte y point coordinate.
  */
-fun decompressPublicKey(compressedBytes: ByteArray, curve: Curve, encode: Boolean = false): BigInteger {
+fun decompressPublicKey(compressedBytes: ByteArray, curve: Curve, legacy: Boolean = false): BigInteger {
     val point = curve.decodePoint(compressedBytes)
     val x = point.ecPoint.xCoord.encoded
     val y = point.ecPoint.yCoord.encoded
-    val bb = ByteBuffer.allocate(PUBLIC_KEY_SIZE + if (encode) 1 else 0)
-    if (encode) {
+    val bb = ByteBuffer.allocate(PUBLIC_KEY_SIZE + if (legacy) 1 else 0)
+    if (legacy) {
         bb.put(0x04)
     }
     bb.put(x)
     bb.put(y)
-    return bb.array().toBigInteger()
+    return bb.array().packIntoBigInteger()
 }

--- a/ec/src/main/kotlin/tech/figure/hdwallet/ec/Curve.kt
+++ b/ec/src/main/kotlin/tech/figure/hdwallet/ec/Curve.kt
@@ -16,7 +16,7 @@ import java.security.spec.EllipticCurve
 /**
  * Defines an elliptic curve point.
  *
- * @property ecPoint
+ * @property ecPoint The curve point.
  */
 class CurvePoint internal constructor(val ecPoint: ECPoint) {
     val x: BigInteger = ecPoint.xCoord.toBigInteger()

--- a/ec/src/main/kotlin/tech/figure/hdwallet/ec/Keys.kt
+++ b/ec/src/main/kotlin/tech/figure/hdwallet/ec/Keys.kt
@@ -50,13 +50,15 @@ class PublicKey(val key: BigInteger, val curve: Curve) {
          * Create a [PublicKey] from an array of bytes using the default curve, [secp256k1Curve].
          *
          * @param bytes The byte array to decode.
+         * @return The [PublicKey]
          */
         fun fromBytes(bytes: ByteArray): PublicKey = fromBytes(bytes, DEFAULT_CURVE)
 
         /**
          * Create a [PublicKey] from a base64 encoded string using the default curve, [secp256k1Curve].
          *
-         * @param bytes The base-64 encoded bytes to decode.
+         * @param encoded The base-64 encoded bytes to decode.
+         * @return The [PublicKey]
          */
         fun fromString(encoded: String): PublicKey = fromBytes(Base64.getDecoder().decode(encoded), DEFAULT_CURVE)
 
@@ -67,6 +69,7 @@ class PublicKey(val key: BigInteger, val curve: Curve) {
          *
          * @param bytes The raw byte array to decode.
          * @param curve The EC curve to use when decoding [bytes] into a coordinate.
+         * @return The [PublicKey]
          */
         fun fromBytes(bytes: ByteArray, curve: Curve): PublicKey = PublicKey(decompressPublicKey(bytes, curve), curve)
     }
@@ -79,5 +82,10 @@ class PublicKey(val key: BigInteger, val curve: Curve) {
  * @property publicKey The public key.
  */
 data class ECKeyPair(val privateKey: PrivateKey, val publicKey: PublicKey) {
+    /**
+     * Convert this [ECKeyPair] instance to a [Pair] of [PublicKey], [PrivateKey].
+     *
+     * @return The converted [Pair].
+     */
     fun toPair(): Pair<PrivateKey, PublicKey> = Pair(privateKey, publicKey)
 }

--- a/ec/src/main/kotlin/tech/figure/hdwallet/ec/Keys.kt
+++ b/ec/src/main/kotlin/tech/figure/hdwallet/ec/Keys.kt
@@ -3,9 +3,10 @@ package tech.figure.hdwallet.ec
 import tech.figure.hdwallet.bech32.Address
 import tech.figure.hdwallet.bech32.toBech32
 import tech.figure.hdwallet.common.hashing.sha256hash160
-import tech.figure.hdwallet.ec.extensions.toBigInteger
+import tech.figure.hdwallet.ec.extensions.packIntoBigInteger
 import tech.figure.hdwallet.ec.extensions.toBytesPadded
 import java.math.BigInteger
+import java.util.Base64
 
 /**
  * Elliptic curve (EC) private key.
@@ -16,16 +17,13 @@ import java.math.BigInteger
 class PrivateKey(val key: BigInteger, val curve: Curve) {
 
     companion object {
-        fun fromBytes(bytes: ByteArray, curve: Curve): PrivateKey =
-            PrivateKey(bytes.toBigInteger(), curve)
+        fun fromBytes(bytes: ByteArray, curve: Curve): PrivateKey = PrivateKey(bytes.packIntoBigInteger(), curve)
     }
 
     fun toPublicKey(): PublicKey = PublicKey(curve.publicFromPrivate(key), curve)
 
-    fun toECKeyPair() = ECKeyPair(this, toPublicKey())
+    fun toECKeyPair(): ECKeyPair = ECKeyPair(this, toPublicKey())
 }
-
-fun BigInteger.toPrivateKey(curve: Curve) = PrivateKey(this, curve)
 
 /**
  * Elliptic curve (EC) public key.
@@ -45,10 +43,32 @@ class PublicKey(val key: BigInteger, val curve: Curve) {
 
     fun address(hrp: String): Address = compressed().sha256hash160().toBech32(hrp).address
 
-    fun compressed() = point().encoded(true)
+    fun compressed(): ByteArray = point().encoded(true)
 
     companion object {
-        fun fromBytes(bytes: ByteArray, curve: Curve): PublicKey = PublicKey(bytes.toBigInteger(), curve)
+        /**
+         * Create a [PublicKey] from an array of bytes using the default curve, [secp256k1Curve].
+         *
+         * @param bytes The byte array to decode.
+         */
+        fun fromBytes(bytes: ByteArray): PublicKey = fromBytes(bytes, DEFAULT_CURVE)
+
+        /**
+         * Create a [PublicKey] from a base64 encoded string using the default curve, [secp256k1Curve].
+         *
+         * @param bytes The base-64 encoded bytes to decode.
+         */
+        fun fromString(encoded: String): PublicKey = fromBytes(Base64.getDecoder().decode(encoded), DEFAULT_CURVE)
+
+        /**
+         * Create a [PublicKey] from an array of bytes using the provided [curve] with byte decompression.
+         *
+         * See [decompressPublicKey].
+         *
+         * @param bytes The raw byte array to decode.
+         * @param curve The EC curve to use when decoding [bytes] into a coordinate.
+         */
+        fun fromBytes(bytes: ByteArray, curve: Curve): PublicKey = PublicKey(decompressPublicKey(bytes, curve), curve)
     }
 }
 

--- a/ec/src/main/kotlin/tech/figure/hdwallet/ec/extensions/BC.kt
+++ b/ec/src/main/kotlin/tech/figure/hdwallet/ec/extensions/BC.kt
@@ -20,7 +20,7 @@ fun X9ECParameters.toCurve(): Curve = Curve(n, g.toCurvePoint(), curve)
 
 fun ECPoint.toCurvePoint(): CurvePoint = CurvePoint(this)
 
-fun ECParameterSpec.toCurve() = Curve(n, g.toCurvePoint(), curve)
+fun ECParameterSpec.toCurve(): Curve = Curve(n, g.toCurvePoint(), curve)
 
 /**
  * Convert a BouncyCastle [BCECPublicKey] to a [Pair] of ([BigInteger], [Curve]).

--- a/ec/src/main/kotlin/tech/figure/hdwallet/ec/extensions/BigInteger.kt
+++ b/ec/src/main/kotlin/tech/figure/hdwallet/ec/extensions/BigInteger.kt
@@ -1,0 +1,30 @@
+package tech.figure.hdwallet.ec.extensions
+
+import java.math.BigInteger
+import tech.figure.hdwallet.ec.Curve
+import tech.figure.hdwallet.ec.PrivateKey
+
+/**
+ * Unpack a [BigInteger] into a padded [ByteArray].
+ *
+ * @param length The final length of the returned byte array.
+ * @return The padded [ByteArray].
+ */
+fun BigInteger.toBytesPadded(length: Int): ByteArray {
+    val result = ByteArray(length)
+    val bytes = toByteArray()
+    val offset = if (bytes[0].toInt() == 0) 1 else 0
+    if (bytes.size - offset > length) {
+         error("Input is too large to put in byte array of size $length")
+    }
+
+    val destOffset = length - bytes.size + offset
+    return bytes.copyInto(result, destinationOffset = destOffset, startIndex = offset)
+}
+
+/**
+ * Convert a [BigInteger] to an EC [PrivateKey] using the supplied curve
+ *
+ * @param curve The curve to use when creating the key. See [tech.figure.hdwallet.ec.secp256k1Curve]
+ */
+fun BigInteger.toPrivateKey(curve: Curve): PrivateKey = PrivateKey(this, curve)

--- a/ec/src/main/kotlin/tech/figure/hdwallet/ec/extensions/BigInteger.kt
+++ b/ec/src/main/kotlin/tech/figure/hdwallet/ec/extensions/BigInteger.kt
@@ -26,5 +26,6 @@ fun BigInteger.toBytesPadded(length: Int): ByteArray {
  * Convert a [BigInteger] to an EC [PrivateKey] using the supplied curve
  *
  * @param curve The curve to use when creating the key. See [tech.figure.hdwallet.ec.secp256k1Curve]
+ * @return The [PrivateKey] instance.
  */
 fun BigInteger.toPrivateKey(curve: Curve): PrivateKey = PrivateKey(this, curve)

--- a/ec/src/main/kotlin/tech/figure/hdwallet/ec/extensions/Bytes.kt
+++ b/ec/src/main/kotlin/tech/figure/hdwallet/ec/extensions/Bytes.kt
@@ -1,28 +1,33 @@
 package tech.figure.hdwallet.ec.extensions
 
 import java.math.BigInteger
+import tech.figure.hdwallet.ec.Curve
+import tech.figure.hdwallet.ec.decompressPublicKey
 
 /**
  * Pack a byte array into an unsigned [BigInteger].
  *
  * @return [BigInteger]
  */
-fun ByteArray.toBigInteger() = BigInteger(1, this)
+@Deprecated("Potentially wrong usage", replaceWith = ReplaceWith("ByteArray.packIntoBigInteger"))
+fun ByteArray.toBigInteger(): BigInteger = BigInteger(1, this)
 
 /**
- * Unpack a [BigInteger] into a padded [ByteArray].
+ * Convert a byte array to [BigInteger], using the supplied curve.
  *
- * @param length The final length of the returned byte array.
- * @return The padded [ByteArray].
+ * See [decompressPublicKey] for details.
+ *
+ * - If [legacy] is false (the default), the returned [BigInteger] will be 65 bytes
+ * - If [legacy] is true (the default), the returned [BigInteger] will be 64 bytes
+ *
+ * @property curve The EC curve to use when interpreting the contents of this byte array as a coordinate.
+ * @property legacy
  */
-fun BigInteger.toBytesPadded(length: Int): ByteArray {
-    val result = ByteArray(length)
-    val bytes = toByteArray()
-    val offset = if (bytes[0].toInt() == 0) 1 else 0
-    if (bytes.size - offset > length) {
-        throw RuntimeException("Input is too large to put in byte array of size $length")
-    }
+fun ByteArray.toBigInteger(curve: Curve, legacy: Boolean = false) = decompressPublicKey(this, curve, legacy)
 
-    val destOffset = length - bytes.size + offset
-    return bytes.copyInto(result, destinationOffset = destOffset, startIndex = offset)
-}
+/**
+ * Pack a byte array into an unsigned [BigInteger].
+ *
+ * @return [BigInteger]
+ */
+fun ByteArray.packIntoBigInteger(): BigInteger = BigInteger(1, this)

--- a/ec/src/main/kotlin/tech/figure/hdwallet/ec/extensions/Bytes.kt
+++ b/ec/src/main/kotlin/tech/figure/hdwallet/ec/extensions/Bytes.kt
@@ -20,10 +20,11 @@ fun ByteArray.toBigInteger(): BigInteger = BigInteger(1, this)
  * - If [legacy] is false (the default), the returned [BigInteger] will be 65 bytes
  * - If [legacy] is true (the default), the returned [BigInteger] will be 64 bytes
  *
- * @property curve The EC curve to use when interpreting the contents of this byte array as a coordinate.
- * @property legacy
+ * @param curve The EC curve to use when interpreting the contents of this byte array as a coordinate.
+ * @param legacy Toggle legacy encoding behavior. See the note in the description for details.
+ * @return [BigInteger]
  */
-fun ByteArray.toBigInteger(curve: Curve, legacy: Boolean = false) = decompressPublicKey(this, curve, legacy)
+fun ByteArray.toBigInteger(curve: Curve, legacy: Boolean = false): BigInteger = decompressPublicKey(this, curve, legacy)
 
 /**
  * Pack a byte array into an unsigned [BigInteger].

--- a/ec/src/test/kotlin/tech/figure/hdwallet/ec/TestKeyConversion.kt
+++ b/ec/src/test/kotlin/tech/figure/hdwallet/ec/TestKeyConversion.kt
@@ -43,7 +43,9 @@ class TestKeyConversion {
 
     @Test
     fun testDecodingPublicKeyFromBase64String() {
-        PublicKey.fromString("AmqcgLOp640tgccRYL/+PtKftP0NwHcDNzUiHNsJV+gb").toJavaECPublicKey()
+        val pubKey = PublicKey.fromString("AmqcgLOp640tgccRYL/+PtKftP0NwHcDNzUiHNsJV+gb").toJavaECPublicKey()
+        assert(pubKey.algorithm == "EC")
+        assert(pubKey.format == "X.509")
     }
 
     @Test

--- a/ec/src/test/kotlin/tech/figure/hdwallet/ec/TestKeyConversion.kt
+++ b/ec/src/test/kotlin/tech/figure/hdwallet/ec/TestKeyConversion.kt
@@ -1,5 +1,12 @@
 package tech.figure.hdwallet.ec
 
+import java.math.BigInteger
+import java.security.KeyPair
+import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPrivateKey
+import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 import tech.figure.hdwallet.common.bc.registerBouncyCastle
 import tech.figure.hdwallet.ec.extensions.toBCECPrivateKey
 import tech.figure.hdwallet.ec.extensions.toBCECPublicKey
@@ -12,13 +19,6 @@ import tech.figure.hdwallet.ec.extensions.toJavaECPrivateKey
 import tech.figure.hdwallet.ec.extensions.toJavaECPublicKey
 import tech.figure.hdwallet.ec.extensions.toKeyPair
 import tech.figure.hdwallet.ec.util.createECKeyPair
-import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPrivateKey
-import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Test
-import java.math.BigInteger
-import java.security.KeyPair
 import java.security.PrivateKey as JavaPrivateKey
 import java.security.PublicKey as JavaPublicKey
 
@@ -42,6 +42,11 @@ class TestKeyConversion {
     }
 
     @Test
+    fun testDecodingPublicKeyFromBase64String() {
+        PublicKey.fromString("AmqcgLOp640tgccRYL/+PtKftP0NwHcDNzUiHNsJV+gb").toJavaECPublicKey()
+    }
+
+    @Test
     @DisplayName("PublicKey: hdwallet -> Java -> hdwallet")
     fun testECPublicKeyConversion() {
         val javaPublicKey = fixturePublicKey.toJavaECPublicKey()
@@ -54,7 +59,7 @@ class TestKeyConversion {
     fun testECPublicKeyConversionCompressed() {
         // Check the encoding
         val encodedDecompressedPublicKey: PublicKey = PublicKey(
-            decompressPublicKey(fixturePublicKey.compressed(), fixturePublicKey.curve, encode = true),
+            decompressPublicKey(fixturePublicKey.compressed(), fixturePublicKey.curve, legacy = true),
             fixturePublicKey.curve
         )
         val encodedIntBytes: ByteArray = encodedDecompressedPublicKey.key.toByteArray()


### PR DESCRIPTION
- Simplify creation of `PublicKey` from base64 encoded string using the default curve + add documentation
- Update documentation for key conversion
- Fix bug in `PublicKey.fromBytes()`, where the byte array was being packed into a `BigInteger` and not being decompressed as would be reasonably expected
- Add `ByteArray.packIntoBigInteger` extension method to pack the contents of a byte array into a `BigInteger` w/o performing decompression
- Add deprecation notice to `ByteArray.toBigInteger` extension method due to potentially wrong usage and point to `ByteArray.packIntoBigInteger`
- Move `BigInteger` extension methods into own file
- Rename `decompressPublicKey` function's `encode` parameter to `legacy` to better explain purpose.
- Make `Curve` and `CurvePoint` constructors internal, since they should never be used outside of the module