### PR TITLE
Allow Account indexing using DerivationPath instance directly

### DIFF
--- a/bip32/src/test/kotlin/tech/figure/hdwallet/bip32/TestBIP32.kt
+++ b/bip32/src/test/kotlin/tech/figure/hdwallet/bip32/TestBIP32.kt
@@ -1,12 +1,12 @@
 package tech.figure.hdwallet.bip32
 
 import tech.figure.hdwallet.bip39.DeterministicSeed
-import tech.figure.hdwallet.bip44.parseBIP44Path
 import tech.figure.hdwallet.encoding.base58.base58DecodeChecked
 import tech.figure.hdwallet.encoding.base58.base58EncodeChecked
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import tech.figure.hdwallet.bip44.PathElements
 
 // test: m/44'/1'/0'/0/0'
 // prod: m/44'/505'/0'/0/0
@@ -25,7 +25,7 @@ class TestBIP32 {
         for (vector in vectors) {
             // Generate the child keys of this seed.
             val seed = DeterministicSeed.fromBytes(seedHex.unhex())
-            val path = vector.path.parseBIP44Path()
+            val path = PathElements.from(vector.path)
             val key = path.fold(seed.toRootKey()) { k, next -> k.childKey(next.hardenedNumber, next.hardened) }
 
             // seed -> extKey -> bip32

--- a/bip44/src/main/kotlin/tech/figure/hdwallet/bip44/DerivationPath.kt
+++ b/bip44/src/main/kotlin/tech/figure/hdwallet/bip44/DerivationPath.kt
@@ -3,6 +3,9 @@ package tech.figure.hdwallet.bip44
 /**
  * Defines a typed representation of a BIP44-style derivation path.
  *
+ * Note: for a BIP-44 derivation path to be valid all 5 components (coin, purpose, account, change, index)
+ * MUST be present.
+ *
  * See https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
  */
 data class DerivationPath(
@@ -64,7 +67,23 @@ data class DerivationPath(
      */
     fun toBuilder(): Builder = Builder(this)
 
-    override fun toString(): String = listOf(purpose, coinType, account, change, index).toPathString()
+    /**
+     * Returns a list of the elements comprising the derivation path.
+     *
+     * The elements returned correspond to the standard defined in
+     * https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki, specifically
+     *
+     * (1) purpose
+     * (2) coin type
+     * (3) account
+     * (4) change
+     * (5) address index
+     *
+     * in the same order.
+     */
+    fun elements(): List<PathElement> = listOf(purpose, coinType, account, change, index)
+
+    override fun toString(): String = elements().toPathString()
 }
 
 /**
@@ -72,7 +91,7 @@ data class DerivationPath(
  */
 fun Iterable<PathElement>.toDerivationPath(): DerivationPath {
     val elements = this.take(5)
-    check(elements.size == 5) { "Missing path elements" }
+    require(elements.size == 5) { "Missing path elements" }
     check(elements[0] is PathElement.Purpose) { "Path element 0 is not purpose" }
     check(elements[1] is PathElement.CoinType) { "Path element 1 is not coin type" }
     check(elements[2] is PathElement.Account) { "Path element 2 is not account" }

--- a/bip44/src/test/kotlin/tech/figure/hdwallet/bip44/TestBIP44.kt
+++ b/bip44/src/test/kotlin/tech/figure/hdwallet/bip44/TestBIP44.kt
@@ -43,6 +43,20 @@ class TestBIP44 {
         assertThrows<IllegalArgumentException> {
             "m/1/1/1/1/1/1".parseBIP44Path()
         }
+        assertThrows<IllegalArgumentException> {
+            DerivationPath.from("m/1/1/1/1/1/1")
+        }
+    }
+
+    @Test
+    fun `parsing a path that does not contain coin, purpose, account, change, and index will fail`() {
+        assertThrows<IllegalArgumentException> {
+            DerivationPath.from("m/44'/505'/0'")
+        }
+        assertThrows<IllegalArgumentException> {
+            DerivationPath.from("m/44'/505'/0'/1")
+        }
+        DerivationPath.from("m/44'/505'/0'/1/1")  // OK
     }
 
     @Test

--- a/hdwallet/src/main/kotlin/tech/figure/hdwallet/wallet/DefaultWallet.kt
+++ b/hdwallet/src/main/kotlin/tech/figure/hdwallet/wallet/DefaultWallet.kt
@@ -43,7 +43,5 @@ class DefaultAccount(
 
     override fun get(path: List<PathElement>): Account = DefaultAccount(hrp, key.childKey(path))
 
-    override fun get(path: DerivationPath): Account = get(path.elements())
-
     override fun get(path: String): Account = DefaultAccount(hrp, key.childKey(path))
 }

--- a/hdwallet/src/main/kotlin/tech/figure/hdwallet/wallet/DefaultWallet.kt
+++ b/hdwallet/src/main/kotlin/tech/figure/hdwallet/wallet/DefaultWallet.kt
@@ -33,6 +33,7 @@ class DefaultAccount(
         key.serialize(publicOnly).base58EncodeChecked()
 
     override val keyPair: ECKeyPair = key.keyPair
+    override fun isRoot(): Boolean = key.depth == ROOT
 
     override fun sign(payload: ByteArray, hash: (ByteArray) -> ByteArray): ByteArray =
         signer.sign(key.keyPair.privateKey, hash(payload)).encodeAsBTC().toByteArray()

--- a/hdwallet/src/main/kotlin/tech/figure/hdwallet/wallet/DefaultWallet.kt
+++ b/hdwallet/src/main/kotlin/tech/figure/hdwallet/wallet/DefaultWallet.kt
@@ -3,7 +3,9 @@ package tech.figure.hdwallet.wallet
 import tech.figure.hdwallet.bech32.Address
 import tech.figure.hdwallet.bip32.AccountType.ROOT
 import tech.figure.hdwallet.bip32.ExtKey
+import tech.figure.hdwallet.bip44.DerivationPath
 import tech.figure.hdwallet.bip44.PathElement
+import tech.figure.hdwallet.bip44.toDerivationPath
 import tech.figure.hdwallet.ec.ECKeyPair
 import tech.figure.hdwallet.encoding.base58.base58EncodeChecked
 import tech.figure.hdwallet.signer.BCECSigner
@@ -22,7 +24,7 @@ class DefaultWallet(private val hrp: String, private val key: ExtKey) : Wallet {
 class DefaultAccount(
     private val hrp: String,
     private val key: ExtKey,
-    private val signer: Signer = BCECSigner()
+    private val signer: Signer = BCECSigner(),
 ) : Account {
 
     override val address: Address = key.keyPair.publicKey.address(hrp)
@@ -38,9 +40,9 @@ class DefaultAccount(
     override fun get(index: Int, hardened: Boolean): Account =
         DefaultAccount(hrp, key.childKey(index, hardened), signer)
 
-    override fun get(path: List<PathElement>): Account =
-        DefaultAccount(hrp, key.childKey(path))
+    override fun get(path: List<PathElement>): Account = DefaultAccount(hrp, key.childKey(path))
 
-    override fun get(path: String): Account =
-        DefaultAccount(hrp, key.childKey(path))
+    override fun get(path: DerivationPath): Account = get(path.elements())
+
+    override fun get(path: String): Account = DefaultAccount(hrp, key.childKey(path))
 }

--- a/hdwallet/src/main/kotlin/tech/figure/hdwallet/wallet/Wallet.kt
+++ b/hdwallet/src/main/kotlin/tech/figure/hdwallet/wallet/Wallet.kt
@@ -20,6 +20,8 @@ import tech.figure.hdwallet.bip44.DerivationPath
  */
 interface Wallet {
     operator fun get(path: List<PathElement>): Account
+
+    operator fun get(path: DerivationPath): Account = get(path.elements())
     operator fun get(path: String): Account = get(PathElements.from(path))
 
     companion object {
@@ -160,8 +162,6 @@ interface Account {
     operator fun get(index: Int, hardened: Boolean = true): Account
 
     operator fun get(path: List<PathElement>): Account
-
-    operator fun get(path: DerivationPath): Account
 
     operator fun get(path: String): Account
 

--- a/hdwallet/src/main/kotlin/tech/figure/hdwallet/wallet/Wallet.kt
+++ b/hdwallet/src/main/kotlin/tech/figure/hdwallet/wallet/Wallet.kt
@@ -131,6 +131,11 @@ interface Account {
     val keyPair: ECKeyPair
 
     /**
+     * Test if the account is derived from a root extended key
+     */
+    fun isRoot(): Boolean
+
+    /**
      * Serialize this account's extended key to the string xprv / xpub representation.
      * @param publicOnly If true, generate the xpub. If false, generate the xprv.
      * @return The extended key in xprv / xpub string format.

--- a/hdwallet/src/main/kotlin/tech/figure/hdwallet/wallet/Wallet.kt
+++ b/hdwallet/src/main/kotlin/tech/figure/hdwallet/wallet/Wallet.kt
@@ -22,6 +22,7 @@ interface Wallet {
     operator fun get(path: List<PathElement>): Account
 
     operator fun get(path: DerivationPath): Account = get(path.elements())
+
     operator fun get(path: String): Account = get(PathElements.from(path))
 
     companion object {
@@ -115,6 +116,26 @@ interface Wallet {
             testnet = testnet,
             curve = curve,
         )
+
+        /**
+         * Convert a base58 check encoded bip32 serialized extended key back into an wallet.
+         * Note: the encoded MUST be a root key, otherwise the operation will raise on exception.
+         *
+         * @param hrp The human-readable prefix for the network this key will be used with.
+         * @param bip32 The base58 check encoded xprv / xpub extended key string.
+         * @return [Wallet]
+         */
+        fun fromBip32(hrp: String, bip32: String): Wallet {
+            val data = try {
+                bip32.base58DecodeChecked()
+            } catch (e: Throwable) {
+                // Eat the exception so no sensitive info gets logged.
+                throw KeyException()
+            }
+            // Only root keys are allowed for wallet creation. The [DefaultWallet] constructor will check if the
+            // given key is a root key by checking its depth:
+            return DefaultWallet(hrp, ExtKey.deserialize(data))
+        }
     }
 }
 

--- a/hdwallet/src/main/kotlin/tech/figure/hdwallet/wallet/Wallet.kt
+++ b/hdwallet/src/main/kotlin/tech/figure/hdwallet/wallet/Wallet.kt
@@ -131,7 +131,8 @@ interface Account {
     val keyPair: ECKeyPair
 
     /**
-     * Test if the account is derived from a root extended key
+     * Test if the account is considered a root account. An account is considered a root if it is not been derived
+     * from a parent [Account].
      */
     fun isRoot(): Boolean
 

--- a/hdwallet/src/main/kotlin/tech/figure/hdwallet/wallet/Wallet.kt
+++ b/hdwallet/src/main/kotlin/tech/figure/hdwallet/wallet/Wallet.kt
@@ -13,7 +13,7 @@ import tech.figure.hdwallet.ec.Curve
 import tech.figure.hdwallet.ec.ECKeyPair
 import tech.figure.hdwallet.encoding.base58.base58DecodeChecked
 import java.security.KeyException
-import tech.figure.hdwallet.bip44.parseBIP44Path
+import tech.figure.hdwallet.bip44.DerivationPath
 
 /**
  * Wallets are the root key representation used to derive [Account]s.
@@ -154,6 +154,8 @@ interface Account {
     operator fun get(index: Int, hardened: Boolean = true): Account
 
     operator fun get(path: List<PathElement>): Account
+
+    operator fun get(path: DerivationPath): Account
 
     operator fun get(path: String): Account
 

--- a/hdwallet/src/test/kotlin/tech/figure/hdwallet/wallet/TestAccount.kt
+++ b/hdwallet/src/test/kotlin/tech/figure/hdwallet/wallet/TestAccount.kt
@@ -1,0 +1,60 @@
+package tech.figure.hdwallet.wallet
+
+import java.security.KeyException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import tech.figure.hdwallet.bip32.AccountType
+import tech.figure.hdwallet.bip32.ExtKey
+import tech.figure.hdwallet.bip32.toRootKey
+import tech.figure.hdwallet.bip39.MnemonicWords
+import tech.figure.hdwallet.bip44.DerivationPath
+import tech.figure.hdwallet.encoding.base58.base58DecodeChecked
+import tech.figure.hdwallet.hrp.Hrp
+
+class TestAccount {
+
+    private val seed =
+        MnemonicWords.of("letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter always")
+            .toSeed("TREZOR".toCharArray())
+
+    private fun Account.toExtKey(publicOnly: Boolean = false): ExtKey =
+        ExtKey.deserialize(serializeExtKey(publicOnly).base58DecodeChecked())
+
+    @Test
+    fun `indexing from a root Account is successful`() {
+        val rootAccount = DefaultAccount(Hrp.ProvenanceBlockchain.testnet, seed.toRootKey())
+        val path = DerivationPath.from("m/44'/1'/0'/0/0")
+        val addressAccount = rootAccount[path]
+        val addressAccountExtKey = addressAccount.toExtKey()
+        assertEquals(AccountType.ADDRESS, addressAccountExtKey.depth)
+    }
+
+    @Test
+    fun `indexing from an Account derived from a partial path is successful`() {
+        val rootAccount = DefaultAccount(Hrp.ProvenanceBlockchain.testnet, seed.toRootKey())
+
+        val childSubAccount = rootAccount["m/44'/1'/123'"]
+        val childSubAccountExtKey = childSubAccount.toExtKey()
+        assertEquals(AccountType.GENERAL, childSubAccountExtKey.depth) // general = account
+
+        val scopeAccount = childSubAccount[0]
+        val scopeAccountExtKey = scopeAccount.toExtKey()
+        assertEquals(AccountType.SCOPE, scopeAccountExtKey.depth)
+
+        val addressAccount = scopeAccount[0]
+        val addressAccountExtKey = addressAccount.toExtKey()
+        assertEquals(AccountType.ADDRESS, addressAccountExtKey.depth)
+    }
+
+    @Test
+    fun `indexing further from a child address Account will fail`() {
+        val rootAccount = DefaultAccount(Hrp.ProvenanceBlockchain.testnet, seed.toRootKey())
+        val path = DerivationPath.from("m/44'/1'/0'/0/0")
+        val addressAccount = rootAccount[path]
+        // Indexing further will fail:
+        assertThrows<KeyException> {
+            addressAccount[0]
+        }
+    }
+}

--- a/hdwallet/src/test/kotlin/tech/figure/hdwallet/wallet/TestAccount.kt
+++ b/hdwallet/src/test/kotlin/tech/figure/hdwallet/wallet/TestAccount.kt
@@ -2,6 +2,8 @@ package tech.figure.hdwallet.wallet
 
 import java.security.KeyException
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import tech.figure.hdwallet.bip32.AccountType
@@ -24,8 +26,13 @@ class TestAccount {
     @Test
     fun `indexing from a root Account is successful`() {
         val rootAccount = DefaultAccount(Hrp.ProvenanceBlockchain.testnet, seed.toRootKey())
+        assertTrue(rootAccount.isRoot())
+
+        // Child accounts are not root:
         val path = DerivationPath.from("m/44'/1'/0'/0/0")
         val addressAccount = rootAccount[path]
+        assertFalse(addressAccount.isRoot())
+
         val addressAccountExtKey = addressAccount.toExtKey()
         assertEquals(AccountType.ADDRESS, addressAccountExtKey.depth)
     }
@@ -33,18 +40,22 @@ class TestAccount {
     @Test
     fun `indexing from an Account derived from a partial path is successful`() {
         val rootAccount = DefaultAccount(Hrp.ProvenanceBlockchain.testnet, seed.toRootKey())
+        assertTrue(rootAccount.isRoot())
 
         val childSubAccount = rootAccount["m/44'/1'/123'"]
         val childSubAccountExtKey = childSubAccount.toExtKey()
         assertEquals(AccountType.GENERAL, childSubAccountExtKey.depth) // general = account
+        assertFalse(childSubAccount.isRoot())
 
         val scopeAccount = childSubAccount[0]
         val scopeAccountExtKey = scopeAccount.toExtKey()
         assertEquals(AccountType.SCOPE, scopeAccountExtKey.depth)
+        assertFalse(scopeAccount.isRoot())
 
         val addressAccount = scopeAccount[0]
         val addressAccountExtKey = addressAccount.toExtKey()
         assertEquals(AccountType.ADDRESS, addressAccountExtKey.depth)
+        assertFalse(addressAccount.isRoot())
     }
 
     @Test

--- a/hdwallet/src/test/kotlin/tech/figure/hdwallet/wallet/TestAccount.kt
+++ b/hdwallet/src/test/kotlin/tech/figure/hdwallet/wallet/TestAccount.kt
@@ -25,12 +25,11 @@ class TestAccount {
 
     @Test
     fun `indexing from a root Account is successful`() {
-        val rootAccount = DefaultAccount(Hrp.ProvenanceBlockchain.testnet, seed.toRootKey())
-        assertTrue(rootAccount.isRoot())
+        val wallet = DefaultWallet(Hrp.ProvenanceBlockchain.testnet, seed.toRootKey())
 
         // Child accounts are not root:
         val path = DerivationPath.from("m/44'/1'/0'/0/0")
-        val addressAccount = rootAccount[path]
+        val addressAccount = wallet[path]
         assertFalse(addressAccount.isRoot())
 
         val addressAccountExtKey = addressAccount.toExtKey()
@@ -39,10 +38,9 @@ class TestAccount {
 
     @Test
     fun `indexing from an Account derived from a partial path is successful`() {
-        val rootAccount = DefaultAccount(Hrp.ProvenanceBlockchain.testnet, seed.toRootKey())
-        assertTrue(rootAccount.isRoot())
+        val wallet = DefaultWallet(Hrp.ProvenanceBlockchain.testnet, seed.toRootKey())
 
-        val childSubAccount = rootAccount["m/44'/1'/123'"]
+        val childSubAccount = wallet["m/44'/1'/123'"]
         val childSubAccountExtKey = childSubAccount.toExtKey()
         assertEquals(AccountType.GENERAL, childSubAccountExtKey.depth) // general = account
         assertFalse(childSubAccount.isRoot())
@@ -60,9 +58,9 @@ class TestAccount {
 
     @Test
     fun `indexing further from a child address Account will fail`() {
-        val rootAccount = DefaultAccount(Hrp.ProvenanceBlockchain.testnet, seed.toRootKey())
+        val wallet = DefaultWallet(Hrp.ProvenanceBlockchain.testnet, seed.toRootKey())
         val path = DerivationPath.from("m/44'/1'/0'/0/0")
-        val addressAccount = rootAccount[path]
+        val addressAccount = wallet[path]
         // Indexing further will fail:
         assertThrows<KeyException> {
             addressAccount[0]


### PR DESCRIPTION
This fixes an oversight on my part to allow a `DerivationPath` to be used for indexing directly.

Additionally:

* this makes `fun String.parseBIP44Path` `internal` since `String.parseBIP44Path` and `PathElements.from()` did the same thing, I felt it was cleaner to expose only one way to parse a path into a BIP-44 style path elements.

* I added a way to test if an `Account` is a "root" account in that it is a top-level account which has not been derived from another `Account` instance.